### PR TITLE
Working coreclr image

### DIFF
--- a/windows/coreclr-release-2-0-0/Dockerfile
+++ b/windows/coreclr-release-2-0-0/Dockerfile
@@ -4,13 +4,18 @@ FROM jashook/vs2017-build-tools
 RUN choco install cmake -y
 RUN choco install python2 -y
 
+RUN set PATH=%PATH%;C:\python27;C:\python27\scripts;"C:\\Program Files\\CMake\\bin"
+
 # Make the tools directory
 RUN mkdir C:\startup_tools
 COPY run_command_cmd64.cmd C:\\startup_tools
 COPY register_dia.cmd C:\\startup_tools
 COPY kill_symbol_server.cmd C:\\startup_tools
+COPY overwrite_mspdbserv.cmd C:\\startup_tools
 COPY setup.cmd C:\\startup_tools
+COPY check_dia_register.cmd C:\\startup_tools
 
-RUN set PATH=%PATH%;C:\python27;C:\python27\scripts;"C:\\Program Files\\CMake\\bin"
+RUN C:\startup_tools\setup.cmd
+RUN C:\startup_tools\check_dia_register.cmd
 
-ENTRYPOINT C:\BuildTools\Common7\Tools\VsDevCmd.bat && C:\startup_tools\setup.cmd && 
+ENTRYPOINT C:\BuildTools\Common7\Tools\VsDevCmd.bat && 

--- a/windows/coreclr-release-2-0-0/check_dia_register.cmd
+++ b/windows/coreclr-release-2-0-0/check_dia_register.cmd
@@ -1,0 +1,18 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+reg query HKEY_CLASSES_ROOT\WOW6432Node\CLSID\{3BFCEA48-620F-4B6B-81F7-B9AF75454C7D}\InprocServer32 > NUL: 2>&1
+if NOT '%ERRORLEVEL%' == '0' (
+    echo.
+    echo.**********************************************************************************
+    echo.Error: We have detected that the msdia120.dll is not registered.   
+    echo.This is necessary for the build to complete without a Class_Not_Registered error.
+    echo.
+    echo.You can fix this by 
+    echo.  1. Launching the "Developer Command Prompt for VS2017" with Administrative privileges
+    echo.  2. Running  regsvr32.exe "%%VSINSTALLDIR%%\Common7\IDE\msdia120.dll"  
+    echo.
+    echo.This will only need to be done once for the lifetime of the machine.
+    echo.For more details see: https://github.com/dotnet/coreclr/issues/11305
+    exit /b 1
+)

--- a/windows/coreclr-release-2-0-0/kill_symbol_server.cmd
+++ b/windows/coreclr-release-2-0-0/kill_symbol_server.cmd
@@ -1,1 +1,4 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
 @for /F "tokens=2 delims= " %%I in ('tasklist^|findstr /I "mspdbsrv.exe"') do taskkill /F /PID %%I>NUL && echo Process killed.

--- a/windows/coreclr-release-2-0-0/overwrite_mspdbserv.cmd
+++ b/windows/coreclr-release-2-0-0/overwrite_mspdbserv.cmd
@@ -1,0 +1,4 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
+move %VCToolsInstallDir%\bin\Hostx86\x86\mspdbst.dll %VCToolsInstallDir%\bin\Hostx86\x86\mspdb140.dll

--- a/windows/coreclr-release-2-0-0/run_command_cmd64.cmd
+++ b/windows/coreclr-release-2-0-0/run_command_cmd64.cmd
@@ -1,1 +1,4 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion EnableExtensions
+
 %SystemRoot%\sysWow64\cmd.exe /S /C "%1"

--- a/windows/coreclr-release-2-0-0/setup.cmd
+++ b/windows/coreclr-release-2-0-0/setup.cmd
@@ -1,3 +1,8 @@
-cmd /c C:\startup_tools\kill_symbol_server.cmd
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion EnableExtensions
 
-cmd /c C:\startup_tools\run_command_cmd64.cmd C:\startup_tools\register_dia.cmd
+call C:\BuildTools\Common7\Tools\VsDevCmd.bat
+
+call C:\startup_tools\run_command_cmd64.cmd C:\startup_tools\register_dia.cmd
+
+call C:\startup_tools\check_dia_register.cmd

--- a/windows/vs2017-build-tools/Dockerfile
+++ b/windows/vs2017-build-tools/Dockerfile
@@ -6,26 +6,95 @@ ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\tools\\nuget
 # Download the Build Tools bootstrapper outside of the PATH.
 ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\\TEMP\\vs_buildtools.exe
 
+# MS Build Tools
+#
+# Microsoft.Component.MSBuild:                              MSBuild
+# Microsoft.VisualStudio.Component.CoreBuildTools:              Visual Studio Build Tools Core
+# Microsoft.VisualStudio.Component.Roslyn.Compiler:             C# and Visual Basic Roslyn compilers
+#
+# VC++ 2017
+#
+# Microsoft.VisualStudio.Component.VC.CoreBuildTools:               Visual C++ Build Tools core features
+# Microsoft.VisualStudio.Component.VC.Redist.14.Latest:             Visual C++ 2017 Redistributable Update
+# Microsoft.VisualStudio.Component.Windows10SDK:                    Windows Universal C Runtime
+# Microsoft.VisualStudio.Component.Static.Analysis.Tools:           Static analysis tools
+# Microsoft.VisualStudio.Component.VC.CMake.Project:                Visual C++ tools for CMake
+# Microsoft.VisualStudio.Component.VC.Tools.x86.x64:                VC++ 2017 v141 toolset (x86,x64)
+#
+# UCRT
+#
+# Microsoft.Component.VC.Runtime.UCRTSDK:                           Windows Universal CRT SDK
+# Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81:        Windows 8.1 SDK and UCRT SDK
+#
+# VC++ Arm(64)
+#
+# Microsoft.VisualStudio.Component.VC.Tools.ARM:                    Visual C++ compilers and libraries for ARM
+# Microsoft.VisualStudio.Component.VC.Tools.ARM64:                  Visual C++ compilers and libraries for ARM64
+#
+# .Net 4.6
+#
+# Microsoft.Net.Component.4.6.1.SDK:                                .NET Framework 4.6.1 SDK
+# Microsoft.Net.Component.4.6.1.TargetingPack:                      .NET Framework 4.6.1 targeting pack
+#
+# VC++ 2015
+#
+# Microsoft.VisualStudio.Component.VC.140:                          VC++ 2015.3 v140 toolset for desktop (x86,x64)
+#
+# Windows SDKs
+# 
+# Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop:      Windows 10 SDK (10.0.16299.0) for Desktop C++ [x86 and x64]
+# Microsoft.VisualStudio.Component.Windows81SDK:                    Windows 8.1 SDK
+# Microsoft.VisualStudio.Component.Windows10SDK.15063.Desktop:      Windows 10 SDK (10.0.15063.0) for Desktop C++ [x86 and x64]
+# Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop.arm:  Windows 10 SDK (10.0.16299.0) for Desktop C++ [ARM and ARM64]
+
 RUN C:\\TEMP\\vs_buildtools.exe --wait --quiet --norestart --nocache --installPath C:\BuildTools \
+####
+#    MSBuild Components
+####
+    --add Microsoft.Component.MSBuild \
     --add Microsoft.VisualStudio.Component.CoreBuildTools \
+    --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
+####
+#   VC++ Components
+####
     --add Microsoft.VisualStudio.Component.VC.CoreBuildTools \
-    --add Microsoft.VisualStudio.Component.Windows10SDK \
     --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest \
+    --add Microsoft.VisualStudio.Component.Windows10SDK \
     --add Microsoft.VisualStudio.Component.Static.Analysis.Tools \
     --add Microsoft.VisualStudio.Component.VC.CMake.Project \
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+####
+#   UCRT
+####
     --add Microsoft.Component.VC.Runtime.UCRTSDK \
+    --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81 \
+####
+####
+#   .Net 4.6
+####
+    --add Microsoft.Net.Component.4.6.1.SDK \
+    --add Microsoft.Net.Component.4.6.1.TargetingPack \
+####
+#   VC++ 2015
+#
+# Notes:
+#
+# msdia120.dll is required for building coreclr.
+#
+####
     --add Microsoft.VisualStudio.Component.VC.140 \
-    --add Microsoft.Component.MSBuild \
-    --add Microsoft.VisualStudio.Component.Roslyn.Compiler \
-    --add Microsoft.VisualStudio.Component.Roslyn.LanguageServices \
-    --add Microsoft.VisualStudio.Component.VC.CLI.Support \
+####
+#    ARM | Arm64
+####
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM \
     --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 \
-    --add Microsoft.VisualStudio.Component.Windows10SDK.10586 \
-    --add Microsoft.VisualStudio.Component.Windows81SDK \
-    --add Microsoft.VisualStudio.Component.Windows10SDK.14393 \
+####
+#   Windows SDK
+####
     --add Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop \
-    --add Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop.arm\
+    --add Microsoft.VisualStudio.Component.Windows81SDK \
+    --add Microsoft.VisualStudio.Component.Windows10SDK.15063.Desktop \
+    --add Microsoft.VisualStudio.Component.Windows10SDK.16299.Desktop.arm \
     || IF "%ERRORLEVEL%"=="3010" EXIT 0
 
 # Start developer command prompt with any other commands specified.


### PR DESCRIPTION
Using the vs2017 build tools the image is now able to build coreclr.
The only caveat is that the image is still unable to restore the coreclr
build tools.